### PR TITLE
Enabling "Notes" on meals

### DIFF
--- a/diabetelegram/models/meal.py
+++ b/diabetelegram/models/meal.py
@@ -8,5 +8,6 @@ class Meal:
     food:                   str = None
     insulin_units:          float = None
     meal_type:              str = None
+    notes:                  str = None
     pre_blood_glucose:      int = None
     post_blood_glucose:     int = None

--- a/diabetelegram/parsers/meal_parser.py
+++ b/diabetelegram/parsers/meal_parser.py
@@ -13,6 +13,7 @@ class MealParser:
             "food": self.parse_food(),
             "insulin_units": self.parse_insulin_units(),
             "meal_type": self.parse_meal_type(),
+            "notes": self.parse_notes(),
             "pre_blood_glucose": self.parse_pre_blood_glucose(),
             "post_blood_glucose": self.parse_post_blood_glucose()
         }
@@ -34,6 +35,9 @@ class MealParser:
 
     def parse_meal_type(self):
         return self._extract_value("tipo")
+
+    def parse_notes(self):
+        return self._extract_value("notas")
 
     def parse_pre_blood_glucose(self):
         pre_blood_glucose_value = self._extract_value("pre")

--- a/diabetelegram/serializers/meal_serializer.py
+++ b/diabetelegram/serializers/meal_serializer.py
@@ -13,6 +13,7 @@ class MealSerializer:
             "food": self.meal.food,
             "insulin_units": self.meal.insulin_units,
             "meal_type": self.meal.meal_type,
+            "notes": self.meal.notes,
             "pre_blood_glucose": self.meal.pre_blood_glucose,
             "post_blood_glucose": self.meal.post_blood_glucose
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+
+from diabetelegram.models.meal import Meal
+
+
+# Data
+@pytest.fixture
+def meal_data():
+    return "pre: 85, post: 123, tipo: lunch, insulina: 2, raciones: 5, comida: Hamburguesa Goiko Kevin Bacon con Sweet Potatos, notas: No me termino todas las patatas - como la mitad aprox"
+
+@pytest.fixture
+def incomplete_meal_data():
+    return "pre: 92, tipo: breakfast, insulina: 1, comida: café y tostadas con jamón, notas: Desayuno en el bar de la esquina"
+
+# Meals
+@pytest.fixture
+def meal():
+    return Meal(
+        carbohydrates_portions=5,
+        food="Hamburguesa Goiko Kevin Bacon con Sweet Potatos",
+        insulin_units=2,
+        meal_type="lunch",
+        notes="No me termino todas las patatas - como la mitad aprox",
+        pre_blood_glucose=85,
+        post_blood_glucose=123
+    )
+
+@pytest.fixture
+def incomplete_meal():
+    return Meal(
+        food="café y tostadas con jamón",
+        insulin_units=1,
+        meal_type="breakfast",
+        notes="Desayuno en el bar de la esquina",
+        pre_blood_glucose=92
+    )
+

--- a/tests/parsers/meal_parser_test.py
+++ b/tests/parsers/meal_parser_test.py
@@ -3,34 +3,24 @@ import pytest
 from diabetelegram.parsers.meal_parser import MealParser
 
 
-# Fixtures
-@pytest.fixture
-def parser():
-    return MealParser("pre: 85, post: 123, tipo: lunch, insulina: 2, raciones: 5, comida: Hamburguesa Goiko Kevin Bacon con Sweet Potatos - Solo un poco sin terminarlas todas")
-
-@pytest.fixture
-def incomplete_parser():
-    return MealParser("pre: 92, tipo: breakfast, insulina: 1, comida: café y tostadas con jamón")
-
-
-# Test cases
-
-def test_to_meal(parser):
-    meal = parser.to_meal()
+def test_to_meal(meal_data):
+    meal = MealParser(meal_data).to_meal()
 
     assert meal.carbohydrates_portions == 5
-    assert meal.food == "Hamburguesa Goiko Kevin Bacon con Sweet Potatos - Solo un poco sin terminarlas todas"
+    assert meal.food == "Hamburguesa Goiko Kevin Bacon con Sweet Potatos"
     assert meal.insulin_units == 2
     assert meal.meal_type == "lunch"
+    assert meal.notes == "No me termino todas las patatas - como la mitad aprox"
     assert meal.pre_blood_glucose == 85
     assert meal.post_blood_glucose == 123
 
-def test_to_meal_with_incomplete_message(incomplete_parser):
-    incomplete_meal = incomplete_parser.to_meal()
+def test_to_meal_with_incomplete_message(incomplete_meal_data):
+    incomplete_meal = MealParser(incomplete_meal_data).to_meal()
 
     assert incomplete_meal.food == "café y tostadas con jamón"
     assert incomplete_meal.insulin_units == 1
     assert incomplete_meal.meal_type == "breakfast"
+    assert incomplete_meal.notes == "Desayuno en el bar de la esquina"
     assert incomplete_meal.pre_blood_glucose == 92
     assert incomplete_meal.post_blood_glucose == None
     assert incomplete_meal.carbohydrates_portions == None

--- a/tests/serializers/meal_serializer_test.py
+++ b/tests/serializers/meal_serializer_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from diabetelegram.serializers.meal_serializer import MealSerializer
+
+
+def test_serializes_meal(meal):
+    serialized_meal = MealSerializer(meal).to_dict()
+
+    assert serialized_meal["carbohydrates_portions"] == 5
+    assert serialized_meal["food"] == "Hamburguesa Goiko Kevin Bacon con Sweet Potatos"
+    assert serialized_meal["insulin_units"] == 2
+    assert serialized_meal["meal_type"] == "lunch"
+    assert serialized_meal["notes"] == "No me termino todas las patatas - como la mitad aprox"
+    assert serialized_meal["pre_blood_glucose"] == 85
+    assert serialized_meal["post_blood_glucose"] == 123
+
+def test_serializes_incomplete_meal(incomplete_meal):
+    serialized_meal = MealSerializer(incomplete_meal).to_dict()
+
+    assert serialized_meal["food"] == "café y tostadas con jamón"
+    assert serialized_meal["insulin_units"] == 1
+    assert serialized_meal["meal_type"] == "breakfast"
+    assert serialized_meal["notes"] == "Desayuno en el bar de la esquina"
+    assert serialized_meal["pre_blood_glucose"] == 92


### PR DESCRIPTION
### What?
We add support for the "Notes" field that was included in the Meal model in https://github.com/AlexGascon/alexgascon/pull/15.

### How?
Adding the field to the `Meal` class, and supporting it in `MealParser` and `MealSerializer`.

We have also added some tests for `MealSerializer`, which was previously untested, and moved the fixtures to the `conftest.py` file following pytest's conventions