### PR TITLE
Pretty meal formatting

### DIFF
--- a/diabetelegram/models/meal.py
+++ b/diabetelegram/models/meal.py
@@ -1,3 +1,4 @@
+import inspect
 from dataclasses import dataclass
 
 
@@ -11,3 +12,18 @@ class Meal:
     notes:                  str = None
     pre_blood_glucose:      int = None
     post_blood_glucose:     int = None
+
+    def __str__(self):
+        meal_text = f"""
+        Meal
+        -----
+        Carbohydrates: {self.carbohydrates_portions} portions
+        Food: {self.food}
+        Insulin: {self.insulin_units} units
+        Meal type: {self.meal_type.capitalize()}
+        Blood Glucose level - Previous: {self.pre_blood_glucose} - Posterior: {self.post_blood_glucose}
+        Notes: {self.notes}
+        """
+
+        return inspect.cleandoc(meal_text)
+

--- a/diabetelegram/services/meal_web_client.py
+++ b/diabetelegram/services/meal_web_client.py
@@ -44,10 +44,17 @@ class MealWebClient:
 
     def _handle_response(self, response):
         if response.status_code in range(200, 300):
-            response_msg = f"CODE: {response.status_code}"
+            response_msg = f"CODE: {response.status_code}\n"
             if response.text:
-                response_msg += f"\n RESPONSE: {response.json()}"
+                response_msg += f"\nMeal:\n{self._format_response_body(response.json())}"
 
             return response_msg
         else:
             return str(response.status_code)
+
+    def _format_response_body(self, response_body):
+        message = ""
+        for key, value in response_body['data'].items():
+            message += f"{key.replace('_', ' ').capitalize()}: {value}\n"
+
+        return message

--- a/tests/models/meal_test.py
+++ b/tests/models/meal_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+from diabetelegram.models.meal import Meal
+
+
+def test_str_generates_a_readable_text(meal):
+    expected = (
+        "Meal\n"
+        "-----\n"
+        "Carbohydrates: 5 portions\n"
+        "Food: Hamburguesa Goiko Kevin Bacon con Sweet Potatos\n"
+        "Insulin: 2 units\n"
+        "Meal type: Lunch\n"
+        "Blood Glucose level - Previous: 85 - Posterior: 123\n"
+        "Notes: No me termino todas las patatas - como la mitad aprox"
+    )
+
+    assert str(meal) == expected


### PR DESCRIPTION
### What?
Right now, both the `__str__` method on `Meal` model and the response returned by the bot after a meal is created / saved return strings not optimized for human-readability: the model returns the one generated by default in dataclasses (the same as in `__repr__`) while the bot simply prints the JSON payload that is included in the response body. 

This makes the bot UX not as good as it could be, so we want it to change.

### How?
We've prepared a more easy to read structure for both the `Meal` objects and the responses returned by the server. They follow an structure similar to the one that can be seen in the following example:

```
        Meal
        -----
        Carbohydrates: 5 portions
        Food: Hamburguesa Goiko Kevin Bacon con Sweet Potatos
        Insulin: 2 units
        Meal type: Lunch
        Blood Glucose level - Previous: 85 - Posterior: 123
        Notes: No me termino todas las patatas - como la mitad aprox
```

In the case of the bot usual response, we also add the meal ID (as it's included in the server response)