### PR TITLE
Enable meal searching

### DIFF
--- a/diabetelegram/commands/command_router.py
+++ b/diabetelegram/commands/command_router.py
@@ -1,4 +1,4 @@
-from diabetelegram.commands.meal_commands import DeleteMealCommand, EditMealCommand, NewMealCommand
+from diabetelegram.commands.meal_commands import DeleteMealCommand, EditMealCommand, NewMealCommand, SearchMealCommand
 from diabetelegram.commands.ping_command import PingCommand
 
 class CommandRouter:
@@ -7,7 +7,8 @@ class CommandRouter:
         '/ping': PingCommand,
         '/newmeal': NewMealCommand,
         '/editmeal': EditMealCommand,
-        '/deletemeal': DeleteMealCommand
+        '/deletemeal': DeleteMealCommand,
+        '/searchmeal': SearchMealCommand
     }
 
     @classmethod

--- a/diabetelegram/commands/meal_commands.py
+++ b/diabetelegram/commands/meal_commands.py
@@ -54,3 +54,19 @@ class DeleteMealCommand:
 
         telegram = TelegramWrapper()
         telegram.reply(message, result)
+
+
+class SearchMealCommand:
+    """Connects with the diabetes API to search meals containing specific words
+
+    It expects the message to have the following form:
+    /searchmeal <search term>
+    """
+
+    @staticmethod
+    def handle(message):
+        _, search_term = message['text'].split(maxsplit=1)
+
+        result = MealWebClient.search_meal(search_term)
+
+        TelegramWrapper().reply(message, result)

--- a/diabetelegram/commands/meal_commands.py
+++ b/diabetelegram/commands/meal_commands.py
@@ -67,6 +67,6 @@ class SearchMealCommand:
     def handle(message):
         _, search_term = message['text'].split(maxsplit=1)
 
-        result = MealWebClient.search_meal(search_term)
+        result = MealWebClient().search_meal(search_term)
 
         TelegramWrapper().reply(message, result)

--- a/diabetelegram/services/meal_web_client.py
+++ b/diabetelegram/services/meal_web_client.py
@@ -45,16 +45,28 @@ class MealWebClient:
     def _handle_response(self, response):
         if response.status_code in range(200, 300):
             response_msg = f"CODE: {response.status_code}\n"
-            if response.text:
-                response_msg += f"\nMeal:\n{self._format_response_body(response.json())}"
 
+            if response.text:
+                response_data = response.json()['data']
+
+                if type(response_data) == list:
+                    response_msg += self._format_meals(response_data)
+                else:
+                    response_msg += self._format_meal(response_data)
             return response_msg
+
         else:
             return str(response.status_code)
 
-    def _format_response_body(self, response_body):
-        message = ""
-        for key, value in response_body['data'].items():
-            message += f"{key.replace('_', ' ').capitalize()}: {value}\n"
+    def _format_meals(self, meals_data):
+        meals_info = [self._format_meal(meal_data) for meal_data in meals_data]
+        meals_separator = "\n-----------------\n"
 
-        return message
+        return meals_separator.join(meals_info)
+
+    def _format_meal(self, meal_data):
+        meal_info = "\nMeal:\n"
+        for key, value in meal_data.items():
+            meal_info += f"{key.replace('_', ' ').capitalize()}: {value}\n"
+
+        return meal_info

--- a/diabetelegram/services/meal_web_client.py
+++ b/diabetelegram/services/meal_web_client.py
@@ -38,6 +38,13 @@ class MealWebClient:
 
         return self._handle_response(response)
 
+    def search_meal(self, search_term):
+        url = self.API_URL
+        params = {'q': search_term}
+
+        response = requests.get(url, params=params, headers=self._build_headers())
+
+        return self._handle_response(response)
 
     def _build_headers(self):
         return {'apikey': self.API_TOKEN}


### PR DESCRIPTION
### What?
One of the most useful things of having a registry of meals and its context is the possibility of searching for past meals to see what effect they had. In order to achieve it, we include the `SearchMeal` command, that allows us to get the information of all the meals that contain a specific word (case insensitive) in its meal or its notes.

### How?
Using the search capabilities of the meals API