### PR TITLE
Enabling the creation of injection via commands

### DIFF
--- a/diabetelegram/commands/command_router.py
+++ b/diabetelegram/commands/command_router.py
@@ -1,3 +1,4 @@
+from diabetelegram.commands.injection_commands import NewInjectionCommand
 from diabetelegram.commands.meal_commands import DeleteMealCommand, EditMealCommand, NewMealCommand, SearchMealCommand
 from diabetelegram.commands.ping_command import PingCommand
 
@@ -8,7 +9,8 @@ class CommandRouter:
         '/newmeal': NewMealCommand,
         '/editmeal': EditMealCommand,
         '/deletemeal': DeleteMealCommand,
-        '/searchmeal': SearchMealCommand
+        '/searchmeal': SearchMealCommand,
+        '/newinjection': NewInjectionCommand,
     }
 
     @classmethod

--- a/diabetelegram/commands/injection_commands.py
+++ b/diabetelegram/commands/injection_commands.py
@@ -1,0 +1,21 @@
+from diabetelegram.parsers.injection_parser import InjectionParser
+from diabetelegram.services.injection_web_client import InjectionWebClient
+from diabetelegram.services.telegram import TelegramWrapper
+
+
+class NewInjectionCommand:
+    """Connects with the diabetes API to store information about an injection
+
+    It expects the message to have the following format:
+    <command> <injection_info>
+    """
+
+    @staticmethod
+    def handle(message):
+        _, injection_info = message['text'].split(maxsplit=1)
+        injection = InjectionParser(injection_info).to_injection()
+
+        result = InjectionWebClient().create_injection(injection)
+
+        telegram = TelegramWrapper()
+        telegram.reply(message, result)

--- a/diabetelegram/models/injection.py
+++ b/diabetelegram/models/injection.py
@@ -1,0 +1,21 @@
+import inspect
+from dataclasses import dataclass
+
+
+@dataclass
+class Injection:
+    """Represents an insulin injection"""
+    injection_type: str = None
+    notes:          str = None
+    units:          float = None
+
+    def __str__(self):
+        injection_text = f"""
+        Injection
+        ----------
+        Type: {self.injection_type}
+        Units: {self.units}
+        Notes: {self.notes}
+        """
+
+        return inspect.cleandoc(injection_text)

--- a/diabetelegram/parsers/base_parser.py
+++ b/diabetelegram/parsers/base_parser.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BaseParser:
+    message: str
+
+    PARTS_SEPARATOR = ","
+    KEY_VALUE_SEPARATOR = ":"
+
+    def _extract_value(self, field_key):
+        field_info = list(filter(lambda m: m.strip().startswith(field_key), self._message_parts()))
+
+        if not field_info:
+            return None
+
+        field_value = field_info[0].split(self.KEY_VALUE_SEPARATOR)[1].strip()
+
+        return field_value
+
+    def _message_parts(self):
+        return self.message.split(self.PARTS_SEPARATOR)

--- a/diabetelegram/parsers/injection_parser.py
+++ b/diabetelegram/parsers/injection_parser.py
@@ -1,0 +1,24 @@
+from diabetelegram.parsers.base_parser import BaseParser
+from diabetelegram.models.injection import Injection
+
+
+class InjectionParser(BaseParser):
+    def to_injection(self):
+        injection_fields = {
+            "injection_type": self.parse_injection_type(),
+            "units": self.parse_units(),
+            "notes": self.parse_notes(),
+        }
+        
+        return Injection(**injection_fields)
+
+    def parse_units(self):
+        units_value = self._extract_value("unidades")
+
+        return float(units_value) if units_value else None
+
+    def parse_injection_type(self):
+        return self._extract_value("tipo")
+
+    def parse_notes(self):
+        return self._extract_value("notas")

--- a/diabetelegram/parsers/meal_parser.py
+++ b/diabetelegram/parsers/meal_parser.py
@@ -1,12 +1,8 @@
-from dataclasses import dataclass
-
+from diabetelegram.parsers.base_parser import BaseParser
 from diabetelegram.models.meal import Meal
 
 
-@dataclass
-class MealParser:
-    message: str
-
+class MealParser(BaseParser):
     def to_meal(self):
         meal_fields = {
             "carbohydrates_portions": self.parse_carbohydrates_portions(),
@@ -48,16 +44,3 @@ class MealParser:
         post_blood_glucose_value = self._extract_value("post")
 
         return int(post_blood_glucose_value) if post_blood_glucose_value else None
-
-    def _extract_value(self, field_key):
-        field_info = list(filter(lambda m: m.strip().startswith(field_key), self._message_parts()))
-
-        if not field_info:
-            return None
-
-        field_value = field_info[0].split(":")[1].strip()
-
-        return field_value
-
-    def _message_parts(self):
-        return self.message.split(",")

--- a/diabetelegram/serializers/injection_serializer.py
+++ b/diabetelegram/serializers/injection_serializer.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from diabetelegram.models.injection import Injection
+
+
+@dataclass
+class InjectionSerializer:
+    injection: Injection
+
+    def to_dict(self):
+        data = {
+            "units": self.injection.units,
+            "type": self.injection.injection_type,
+            "notes": self.injection.notes,
+        }
+
+        return {key: value for key, value in data.items() if value is not None}

--- a/diabetelegram/services/base_web_client.py
+++ b/diabetelegram/services/base_web_client.py
@@ -1,0 +1,20 @@
+import os
+
+
+class BaseWebClient:
+    """Handles interactions with the Diabetes API"""
+    API_URL = os.environ['DIABETES_API_URL']
+    API_TOKEN = os.environ['DIABETES_API_TOKEN']
+
+    def _build_headers(self):
+        return {'apikey': self.API_TOKEN}
+
+    def _format_response_body(self, response_body):
+        message = ""
+        for key, value in response_body['data'].items():
+            message += self._format_item(key, value) + "\n"
+
+        return message
+
+    def _format_item(self, key, value):
+        return f"{key.replace('_', ' ').capitalize()}: {value}"

--- a/diabetelegram/services/injection_web_client.py
+++ b/diabetelegram/services/injection_web_client.py
@@ -1,0 +1,27 @@
+import requests
+
+from diabetelegram.serializers.injection_serializer import InjectionSerializer
+from diabetelegram.services.base_web_client import BaseWebClient
+
+
+class InjectionWebClient(BaseWebClient):
+    def create_injection(self, injection):
+        """Send the request to store data of a new injection"""
+        body = {'injection': InjectionSerializer(injection).to_dict()}
+
+        response = requests.post(self._base_url(), headers=self._build_headers(), json=body)
+
+        return self._handle_response(response)
+
+    def _base_url(self):
+        return f"{self.API_URL}/injections"
+
+    def _handle_response(self, response):
+        if response.status_code in range(200, 300):
+            response_msg = f"CODE: {response.status_code}\n"
+            if response.text:
+                response_msg += f"\nInjection:\n{self._format_response_body(response.json())}"
+
+            return response_msg
+        else:
+            return str(response.status_code)


### PR DESCRIPTION
### What?
In order to increase the number of possibilities of the bot, we'll add logic that enables the creation and modification of Injections from the bot

### How?
We have used a structure similar to the one that is in place for the creation of Meals:
* **Model to represent injections:** We have created the `Injection` model, that can be used to represent Injections in the project. An injection can have the fields `type`, `units` and `notes`.
* **WebClient to communicate with the API:** Once the injection has been represented, we will send a request to Alexgascon's site API to trigger the storage of its information in the DB. In order to reuse as much logic as possible from the Meals implementation, we have extracted it to a base class (`BaseWebClient`) from which both now inherit.
* **Parsers and serializers to interpret the information:** We follow an Hexagonal Architecture pattern in each of the Domain models: the class that operates with them (in this case, the WebClients) only require that the object they are given is the object they operate with (Meal/Injection); the processing to convert the input information into / output information from them is encapsulated on Parsers and Serializers. Therefore, we have created some for the Injection model. Here too, we have reused the logic that initially was implemented for the Meals model 
* **Command:** We have created a command that acts as the handler of the data received by the Lambda funcion, and that triggers the rest of the operations that need to be executed