### PR TITLE
Minor fixes related with Event-Oriented implementation

### DIFF
--- a/diabetelegram/commands/injection_commands.py
+++ b/diabetelegram/commands/injection_commands.py
@@ -19,7 +19,7 @@ class NewInjectionCommand:
         injection = InjectionParser(injection_info).to_injection()
 
         if os.environ['EVENT_ORIENTED_ON'] == 'true':
-            result = InjectionSNSClient.insulin_injected(injection)
+            result = InjectionSNSClient().insulin_injected(injection)
         else:
             result = InjectionWebClient().create_injection(injection)
 

--- a/diabetelegram/services/injection_sns_client.py
+++ b/diabetelegram/services/injection_sns_client.py
@@ -20,6 +20,6 @@ class InjectionSNSClient:
             'Message': json.dumps(InjectionSerializer(injection).to_dict())
         }
 
-        response = self.sns.publish(sns_payload)
+        response = self.sns.publish(**sns_payload)
 
         return response['MessageId']

--- a/diabetelegram/services/meal_sns_client.py
+++ b/diabetelegram/services/meal_sns_client.py
@@ -20,7 +20,7 @@ class MealSNSClient:
             'Message': json.dumps(MealSerializer(meal).to_dict())
         }
 
-        response = self.sns.publish(sns_payload)
+        response = self.sns.publish(**sns_payload)
 
         return response['MessageId']
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,6 +3,12 @@ service: diabetelegram
 provider:
   name: aws
   runtime: python3.7
+  iamRoleStatements:
+    - Effect: 'Allow'
+      Action: 'sns:*'
+      Resource:
+        - '${env:INSULIN_INJECTED_TOPIC_ARN}'
+        - '${env:MEAL_EATEN_TOPIC_ARN}'
 
 functions:
   hello:

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,6 +3,7 @@ service: diabetelegram
 provider:
   name: aws
   runtime: python3.7
+  region: eu-west-1
   iamRoleStatements:
     - Effect: 'Allow'
       Action: 'sns:*'


### PR DESCRIPTION
## What?
Fixing the following bugs that were introduced when merging the original implementation:
- Instantiating `InjectionSNSClient` to use the `insulin_injected` method
- Using keyword arguments when using the `publish` method on the boto3 SNS client
- Specifying explicitly the region in which the Lambda function will be deployed (eu-west-1, Ireland), as otherwise the Lambda is deployed in one of the US regions
- Granting permissions to publish messages in the SNS topics that we'll be using