### PR TITLE
Fixing ref match pattern

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,5 +31,5 @@ jobs:
     - name: Install Serverless plugins
       run: npm install
     - name: Deploy
-      if: github.ref == 'master'
+      if: github.ref == '**/master'
       run: serverless deploy


### PR DESCRIPTION
The actual value of github.ref is not the branch name, but its reference (which is a string similar to ref/heads/master). With this change, we fix the Github Actions workflow so we can continue using the `deploy` job