### PR TITLE
Enabling different deployment stages

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,6 +2,7 @@ service: diabetelegram
 
 provider:
   name: aws
+  stage: ${self:custom.stage}
   runtime: python3.7
   region: eu-west-1
   iamRoleStatements:
@@ -13,6 +14,7 @@ provider:
 
 functions:
   hello:
+    name: diabetelegram-${self:custom.stage}
     handler: diabetelegram.handler.handler
     events:
       - http:
@@ -25,5 +27,4 @@ plugins:
 custom:
   pythonRequirements:
     usePipenv: true
-  dotenv:
-    path: .env
+  stage: ${opt:env, 'prod'}


### PR DESCRIPTION
This commit modifies the serverless configuration to allow us to specify an environment when running commands. We do it by setting a custom variable called `stage` whose value is set by the `--env` argument on the CLI (or to 'prod' if the argument is not present)

In order to make sure that we have different resources for each stage, we have modified the provider config and the function name to include the stage in its value

We have also changed the configuration of the serverless-dotenv-plugin configuration. Now we'll have different .env files, called `.env.<stage>` (e.g. `.env.prod`, `.env.beta`). The plugin automatically infers those names if a `.env` file is not present, so by using the default configuration we'll enable that behavior