### PR TITLE
Remove the "Insulin" step when adding injections

### DIFF
--- a/diabetelegram/actions/constants.py
+++ b/diabetelegram/actions/constants.py
@@ -1,13 +1,11 @@
-from diabetelegram.actions.insulin_actions import InsulinAction, InsulinBasalAction, InsulinBolusAction, InsulinUnitsAction
+from diabetelegram.actions.insulin_actions import InsulinBasalAction, InsulinBolusAction, InsulinUnitsAction
 
 class Actions:
-    Insulin = InsulinAction
     Basal = InsulinBasalAction
     Bolus = InsulinBolusAction
     Units = InsulinUnitsAction
 
     ALL = [
-        Insulin,
         Basal,
         Bolus,
         Units

--- a/diabetelegram/actions/factory.py
+++ b/diabetelegram/actions/factory.py
@@ -24,10 +24,6 @@ class ActionFactory:
         return cls.FACTORIES[action_class]
 
     @staticmethod
-    def insulin_factory(*args):
-        return Actions.Insulin(*args)
-
-    @staticmethod
     def basal_factory(*args):
         return Actions.Basal(*args)
 
@@ -40,7 +36,6 @@ class ActionFactory:
         return Actions.Units(*args)
 
     FACTORIES = {
-        Actions.Insulin: insulin_factory.__func__,
         Actions.Basal: basal_factory.__func__,
         Actions.Bolus: bolus_factory.__func__,
         Actions.Units: units_factory.__func__

--- a/diabetelegram/actions/insulin_actions.py
+++ b/diabetelegram/actions/insulin_actions.py
@@ -5,22 +5,9 @@ from diabetelegram.services.state_manager import StateManager
 from diabetelegram.services.telegram import TelegramWrapper
 
 
-class InsulinAction(BaseAction):
-    def matches(self):
-        return self.message_text == 'insulin'
-
-    def handle(self):
-        self.state_manager.set('insulin')
-
-        response = "What type of insulin do you want to add?"
-
-        self.telegram.reply(self.message, response)
-
-
 class InsulinBasalAction(BaseAction):
     def matches(self):
-        state = self.state_manager.get()
-        return state == 'insulin' and self.message_text == 'basal'
+        return self.message_text == 'basal'
 
     def handle(self):
         self.state_manager.set('basal')
@@ -32,8 +19,7 @@ class InsulinBasalAction(BaseAction):
 
 class InsulinBolusAction(BaseAction):
     def matches(self):
-        state = self.state_manager.get()
-        return state == 'insulin' and self.message_text == 'bolus'
+        return self.message_text == 'bolus'
 
     def handle(self):
         self.state_manager.set('bolus')

--- a/tests/actions/insulin_actions_test.py
+++ b/tests/actions/insulin_actions_test.py
@@ -13,52 +13,16 @@ def sns_client(mocker):
     sns_instance = sns_mock.return_value
     return sns_instance
 
-class TestInsulinAction:
-    def build_action(self, message):
-        return MockActionFactory.build(Actions.Insulin, message)
-
-    @pytest.mark.parametrize('message', ['Insulin'], indirect=True)
-    def test_matches_if_the_message_text_is_insulin(self, message):
-        insulin_action = self.build_action(message)
-
-        assert insulin_action.matches()
-
-    @pytest.mark.parametrize('message', ['some message'], indirect=True)
-    def test_does_not_match_if_the_message_text_is_other(self, message):
-        insulin_action = self.build_action(message)
-
-        assert not insulin_action.matches()
-
-    def test_handle_sets_the_state_to_insulin(self, message):
-        insulin_action = self.build_action(message)
-
-        insulin_action.handle()
-
-        insulin_action.state_manager.set.assert_called_with('insulin')
-
-    def test_handle_sends_a_telegram_response(self, message):
-        insulin_action = self.build_action(message)
-
-        insulin_action.handle()
-
-        insulin_action.telegram.reply.assert_called_once()
-
 
 class TestInsulinBasalAction:
     def build_action(self, message, state_manager):
         return MockActionFactory.build(Actions.Basal, message, state_manager)
 
-    @pytest.mark.parametrize('state, message', [('insulin', 'basal')], indirect=True)
-    def test_matches_if_the_message_is_basal_and_state_is_insulin(self, state, message):
+    @pytest.mark.parametrize('state, message', [('whatever', 'basal')], indirect=True)
+    def test_matches_if_the_message_is_basal(self, state, message):
         basal_action = self.build_action(message, state)
 
         assert basal_action.matches()
-
-    @pytest.mark.parametrize('state, message', [('some state', 'basal')], indirect=True)
-    def test_does_not_match_if_state_is_not_insulin(self, state, message):
-        basal_action = self.build_action(message, state)
-
-        assert not basal_action.matches()
 
     @pytest.mark.parametrize('state, message', [('insulin', 'whatever')], indirect=True)
     def test_does_not_match_if_the_message_is_not_basal(self, state, message):
@@ -85,17 +49,11 @@ class TestInsulinBolusAction:
     def build_action(self, message, state_manager):
         return MockActionFactory.build(Actions.Bolus, message, state_manager)
 
-    @pytest.mark.parametrize('state, message', [('insulin', 'bolus')], indirect=True)
-    def test_matches_if_the_message_is_bolus_and_state_is_insulin(self, state, message):
+    @pytest.mark.parametrize('state, message', [('whatever', 'bolus')], indirect=True)
+    def test_matches_if_the_message_is_bolus(self, state, message):
         bolus_action = self.build_action(message, state)
 
         assert bolus_action.matches()
-
-    @pytest.mark.parametrize('state, message', [('some state', 'bolus')], indirect=True)
-    def test_does_not_match_if_state_is_not_insulin(self, state, message):
-        bolus_action = self.build_action(message, state)
-
-        assert not bolus_action.matches()
 
     @pytest.mark.parametrize('state, message', [('insulin', 'whatever')], indirect=True)
     def test_does_not_match_if_the_message_is_not_bolus(self, state, message):


### PR DESCRIPTION
In order to simplify the addition of Insulin injections, we'll skip the need of starting with an "Insulin" message and letting the user go directly to specifying the type of insulin ("Basal" or "Bolus")

The initial goal behind this two-step validation was to avoid having too many "entrypoint steps", but currently we're far from that and removing a step provides a better UX. If at any point we want to go back to this approach, we only have to revert this commit