### PR TITLE
Simplifying deployments

### DIFF
--- a/scripts/deploy-beta.sh
+++ b/scripts/deploy-beta.sh
@@ -1,0 +1,1 @@
+serverless deploy --env beta

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,0 +1,1 @@
+serverless deploy --env prod

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,6 +17,7 @@ provider:
         - 'Fn::GetAtt': [ StateTable, Arn ]
   environment:
     stage: ${self:custom.stage}
+  profile: ${self:custom.profiles.${self:custom.stage}, 'beta'}
 
 functions:
   hello:
@@ -54,3 +55,6 @@ custom:
   pythonRequirements:
     usePipenv: true
   stage: ${opt:env, 'prod'}
+  profiles:
+    beta: beta
+    prod: default


### PR DESCRIPTION
Linking AWS profiles to the environment to which we are deploying (see
https://serverless.com/framework/docs/providers/aws/guide/credentials#per-stage-profiles for more information)

Creating two scripts, `scripts/deploy-beta.sh` and
`scripts/deploy-prod.sh`, to encapsulate the deployment actions there