### PR TITLE
Insulin summaries

### DIFF
--- a/diabetelegram/actions/constants.py
+++ b/diabetelegram/actions/constants.py
@@ -1,5 +1,5 @@
 from diabetelegram.actions.expense_actions import ExpenseAction, ExpenseAmountAction, ExpenseCategoryAction, ExpenseDescriptionAction
-from diabetelegram.actions.insulin_actions import InsulinBasalAction, InsulinBolusAction, InsulinUnitsAction
+from diabetelegram.actions.insulin_actions import InsulinBasalAction, InsulinBolusAction, InsulinUnitsAction, InsulinSummaryAction
 
 
 class Actions:
@@ -10,6 +10,7 @@ class Actions:
     Basal = InsulinBasalAction
     Bolus = InsulinBolusAction
     Units = InsulinUnitsAction
+    InsulinSummary = InsulinSummaryAction
 
     ALL = [
         Expense,
@@ -18,5 +19,6 @@ class Actions:
         ExpenseDescription,
         Basal,
         Bolus,
-        Units
+        Units,
+        InsulinSummary
     ]

--- a/diabetelegram/actions/factory.py
+++ b/diabetelegram/actions/factory.py
@@ -51,6 +51,10 @@ class ActionFactory:
     def units_factory(*args):
         return Actions.Units(*args)
 
+    @staticmethod
+    def insulin_summary_factory(*args):
+        return Actions.InsulinSummary(*args)
+
     FACTORIES = {
         Actions.Expense: expense_factory.__func__,
         Actions.ExpenseAmount: expense_amount_factory.__func__,
@@ -58,5 +62,6 @@ class ActionFactory:
         Actions.ExpenseDescription: expense_description_factory.__func__,
         Actions.Basal: basal_factory.__func__,
         Actions.Bolus: bolus_factory.__func__,
-        Actions.Units: units_factory.__func__
+        Actions.Units: units_factory.__func__,
+        Actions.InsulinSummary: insulin_summary_factory.__func__
     }

--- a/diabetelegram/actions/insulin_actions.py
+++ b/diabetelegram/actions/insulin_actions.py
@@ -1,6 +1,7 @@
 from diabetelegram.actions.base_action import BaseAction
 from diabetelegram.models.injection import Injection
 from diabetelegram.services.injection_sns_client import InjectionSNSClient
+from diabetelegram.services.summary_sns_client import SummarySNSClient
 from diabetelegram.services.state_manager import StateManager
 from diabetelegram.services.telegram import TelegramWrapper
 
@@ -44,3 +45,13 @@ class InsulinUnitsAction(BaseAction):
         self.state_manager.set('initial')
 
         self.telegram.reply(self.message, result)
+
+
+class InsulinSummaryAction(BaseAction):
+    def matches(self):
+        return self.message_text.lower() == 'summary'
+
+    def handle(self):
+        SummarySNSClient().summary_requested()
+
+        self.state_manager.set('initial')

--- a/diabetelegram/services/summary_sns_client.py
+++ b/diabetelegram/services/summary_sns_client.py
@@ -1,0 +1,19 @@
+import json
+import os
+
+import boto3
+
+
+class SummarySNSClient:
+    def __init__(self):
+        self.sns = boto3.client('sns')
+        self.topic_name = os.environ['SUMMARY_REQUESTED_TOPIC_ARN']
+
+    def summary_requested(self):
+        sns_payload = {
+            'TopicArn': self.topic_name,
+            'Message': json.dumps({})
+        }
+
+        response = self.sns.publish(**sns_payload)
+        return response['MessageId']

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,7 @@ provider:
         - '${env:INSULIN_INJECTED_TOPIC_ARN}'
         - '${env:MEAL_EATEN_TOPIC_ARN}'
         - '${env:MONEY_SPENT_TOPIC_ARN}'
+        - '${env:SUMMARY_REQUESTED_TOPIC_ARN}'
     - Effect: 'Allow'
       Action: 'dynamodb:*'
       Resource:


### PR DESCRIPTION
### What?
Adding the possibility of requesting a summary of the latest insulin information. In order to do so, we have created a new SNS topic and an action.

The action will be activated when the message matches "summary" (case insensitive) and it will publish the SNS event and return the application to the initial state.

Currently, this summary includes a graph with the pattern of the insulin used in the last 24h, but we may add more information in the future