### PR TITLE
Enabling Meal creation

### DIFF
--- a/diabetelegram/actions/constants.py
+++ b/diabetelegram/actions/constants.py
@@ -1,6 +1,7 @@
 from diabetelegram.actions.dexcom_actions import DexcomAction
 from diabetelegram.actions.expense_actions import ExpenseAction, ExpenseAmountAction, ExpenseCategoryAction, ExpenseDescriptionAction
 from diabetelegram.actions.insulin_actions import InsulinBasalAction, InsulinBolusAction, InsulinUnitsAction, InsulinSummaryAction
+from diabetelegram.actions.meal_actions import MealAction, MealFoodAction
 
 
 class Actions:
@@ -13,6 +14,8 @@ class Actions:
     Units = InsulinUnitsAction
     InsulinSummary = InsulinSummaryAction
     Dexcom = DexcomAction
+    Meal = MealAction
+    MealFood = MealFoodAction
 
     ALL = [
         Expense,
@@ -23,5 +26,7 @@ class Actions:
         Bolus,
         Units,
         InsulinSummary,
-        Dexcom
+        Dexcom,
+        Meal,
+        MealFood
     ]

--- a/diabetelegram/actions/meal_actions.py
+++ b/diabetelegram/actions/meal_actions.py
@@ -1,0 +1,34 @@
+from diabetelegram.actions.base_action import BaseAction
+from diabetelegram.models.meal import Meal
+from diabetelegram.services.meal_sns_client import MealSNSClient
+
+
+class MealAction(BaseAction):
+    MEAL_MESSAGE = 'meal'
+    MEAL_STATE = 'meal'
+    TELEGRAM_REPLY = 'What food did you eat?'
+
+    def matches(self):
+        return self.message_text.lower() == self.MEAL_MESSAGE
+
+    def handle(self):
+        self.state_manager.set(self.MEAL_STATE)
+
+        self.telegram.reply(self.message, self.TELEGRAM_REPLY)
+
+class MealFoodAction(BaseAction):
+    MEAL_STATE = 'meal'
+    INITIAL_STATE = 'initial'
+
+    def matches(self):
+        state = self.state_manager.get()
+        return state == self.MEAL_STATE
+
+    def handle(self):
+        self.state_manager.set('initial')
+
+        meal = Meal(food=self.message_text)
+        message_id = MealSNSClient().meal_eaten(meal)
+
+        reply = f'Meal published.\nMessage ID: {message_id}'
+        self.telegram.reply(self.message, reply)

--- a/tests/actions/meal_actions_test.py
+++ b/tests/actions/meal_actions_test.py
@@ -1,0 +1,96 @@
+from unittest import mock
+
+import pytest
+
+from diabetelegram.actions.constants import Actions
+from diabetelegram.models.meal import Meal
+from tests.fixtures.actions import MockActionFactory
+
+
+@pytest.fixture
+def sns_client(mocker):
+    sns_mock = mocker.patch('diabetelegram.actions.meal_actions.MealSNSClient')
+    sns_instance = sns_mock.return_value
+    return sns_instance
+
+
+class TestMealAction:
+    def build_action(self, message, state_manager=None):
+        return MockActionFactory.build(Actions.Meal, message, state_manager=state_manager)
+
+    @pytest.mark.parametrize('message', ['Meal'], indirect=True)
+    def test_matches_if_message_is_meal(self, message):
+        action = self.build_action(message)
+
+        assert action.matches()
+
+    @pytest.mark.parametrize('message', ['mEaL'], indirect=True)
+    def test_matches_is_case_insensitive(self, message):
+        action = self.build_action(message)
+
+        assert action.matches()
+
+    @pytest.mark.parametrize('message', ['Random message'], indirect=True)
+    def test_does_not_match_with_a_different_message(self, message):
+        action = self.build_action(message)
+
+        assert not action.matches()
+
+    @pytest.mark.parametrize('message', ['Meal'], indirect=True)
+    def test_handle_sets_the_next_state(self, message):
+        action = self.build_action(message)
+
+        action.handle()
+
+        action.state_manager.set.assert_called_once_with('meal')
+
+    @pytest.mark.parametrize('message', ['Meal'], indirect=True)
+    def test_handle_sends_a_telegram_response(self, message):
+        action = self.build_action(message)
+
+        action.handle()
+
+        action.telegram.reply.assert_called_once()
+
+class TestMealFoodAction:
+    def build_action(self, message, state_manager=None):
+        return MockActionFactory.build(Actions.MealFood, message, state_manager=state_manager)
+
+    @pytest.mark.parametrize('state', ['meal'], indirect=True)
+    def test_matches_if_state_is_meal(self, message, state):
+        action = self.build_action(message, state_manager=state)
+
+        assert action.matches()
+
+    @pytest.mark.parametrize('state', ['random-state'], indirect=True)
+    def test_does_not_match_if_state_is_not_meal(self, state, message):
+        action = self.build_action(message, state)
+
+        assert not action.matches()
+
+    @pytest.mark.parametrize('state', ['meal'], indirect=True)
+    def test_handle_sets_the_state_to_initial(self, message, state, sns_client):
+        action = self.build_action(message, state_manager=state)
+
+        action.handle()
+
+        action.state_manager.set.assert_called_once_with('initial')
+
+
+    @pytest.mark.parametrize('message, state', [('pizza', 'meal')], indirect=True)
+    def test_handle_publishes_the_meal(self, message, state, sns_client):
+        action = self.build_action(message, state_manager=state)
+
+        action.handle()
+
+        meal = Meal(food='pizza')
+        sns_client.meal_eaten.assert_called_once_with(meal)
+
+    
+    @pytest.mark.parametrize('message, state', [('pizza', 'meal')], indirect=True)
+    def test_handle_sends_a_telegram_response(self, message, state, sns_client):
+        action = self.build_action(message, state_manager=state)
+
+        action.handle()
+
+        action.telegram.reply.assert_called_once()

--- a/tests/serializers/meal_serializer_test.py
+++ b/tests/serializers/meal_serializer_test.py
@@ -22,3 +22,5 @@ def test_serializes_incomplete_meal(incomplete_meal):
     assert serialized_meal["meal_type"] == "breakfast"
     assert serialized_meal["notes"] == "Desayuno en el bar de la esquina"
     assert serialized_meal["pre_blood_glucose"] == 92
+    assert not "post_blood_glucose" in serialized_meal
+    assert not "carbohydrates_portions" in serialized_meal


### PR DESCRIPTION
### Description
Adding the possibility to log meals. Currently we'll make it simple and 
only allow to add food details, not any of the other fields.

The serializer, SNS client and model were already created from the previous
version of the app so we just needed to create the actions and its tests

Additionally, we modified the MealSerializer test to make sure that empty fields are not serialized