### PR TITLE
Use Pipenv on GitHub action workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,12 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Lock Pipfile dependencies in requirements.txt
-      run: python -m pip install --upgrade pip && pip install pipenv && pipenv lock -r > ./requirements.txt && pipenv lock -r -d > ./requirements-dev.txt
+    - name: Install pipenv
+      run: python -m pip install --upgrade pip && pip install pipenv
     - name: Install dependencies
-      run: pip install -r ./requirements.txt && pip install -r ./requirements-dev.txt
+      run: pipenv install --dev
     - name: Run tests
-      run: pytest
+      run: pipenv run pytest
   build-and-deploy:
     name: Deploy the project
     needs: test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Lock Pipfile dependencies in requirements.txt
-      run: pip install pipenv && pipenv lock -r > ./requirements.txt && pipenv lock -r -d > ./requirements-dev.txt
+      run: python -m pip install --upgrade pip && pip install pipenv && pipenv lock -r > ./requirements.txt && pipenv lock -r -d > ./requirements-dev.txt
     - name: Install dependencies
       run: pip install -r ./requirements.txt && pip install -r ./requirements-dev.txt
     - name: Run tests


### PR DESCRIPTION
### Description
We're getting a ResolutionImpossible error on the GitHub action
execution, despite there hasn't been any dependency change recently
Full error message:

```
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
The conflict is caused by:
    The user requested idna==2.9
    moto 1.3.14 depends on idna<2.9 and >=2.5
```

Besides, we're trying to install the same dependencies that are working
perfectly fine on local environments, so there cannot be any problem
with the dependencies

The workflow should work perfectly fine because we're using the same dependencies than in the local environment, so this probably is a problem with the pip resolver. There are a few similar issues open on their main repo so it's definitely a possibility.

In any case, to avoid having to worry about two different dependency management systems, Pipenv locally and pip on GH Actions, we'll change the latter to use Pipenv too